### PR TITLE
Update sudo cp commands under "prep the phone"

### DIFF
--- a/_posts/2024-01-05-virtual_machines_on_android_14_using_KVM.md
+++ b/_posts/2024-01-05-virtual_machines_on_android_14_using_KVM.md
@@ -83,9 +83,9 @@ $ passwd <username>
 $ chsh -s /bin/bash <username>
 $ exit
 $ sudo mkdir -p ./ubuntu-rootfs/gvisor-tap-vsock
-$ sudo cp -r ./gvisor-tap-vsock-arm64/bin/* ./ubuntu-rootfs/gvisor-tap-vsock
+$ sudo cp -r ./gvisor-tap-vsock-arm64/bin ./ubuntu-rootfs/gvisor-tap-vsock
 $ sudo mkdir -p ./vm-host/gvisor-tap-vsock
-$ sudo cp -r ./gvisor-tap-vsock-android/bin/* ./vm-host/gvisor-tap-vsock
+$ sudo cp -r ./gvisor-tap-vsock-android/bin ./vm-host/gvisor-tap-vsock
 $ sudo umount ./ubuntu-rootfs
 $ sudo umount ./vm-host
 ```


### PR DESCRIPTION
Following the current instructions, the command `/storage/emulated/0/kvm/vm-host/gvisor-tap-vsock/bin/gvproxy -debug -listen vsock://:1024 -listen unix:///storage/emulated/0/kvm/vm-host/network.sock` returns the error that it can't find the `bin` folder.

Changing the `sudo cp` commands shown 
![image](https://github.com/ccrutchf/ccrutchf.github.io/assets/98805774/cf1a69e3-2452-466a-b7f9-072698ccb58b)
to copy the entire `bin` directory, not just its contents, seems to fix the issue.

That is, the new commands would be `$ sudo cp -r ./gvisor-tap-vsock-arm64/bin ./ubuntu-rootfs/gvisor-tap-vsock` and `$ sudo cp -r ./gvisor-tap-vsock-android/bin ./vm-host/gvisor-tap-vsock`